### PR TITLE
Typos in notebooks

### DIFF
--- a/Notebooks_Peptide-ID-and-Quant-of-MS-Data/Lesson_4.ipynb
+++ b/Notebooks_Peptide-ID-and-Quant-of-MS-Data/Lesson_4.ipynb
@@ -215,7 +215,7 @@
         "        for spectrum in spectra:\n",
         "            scanNumber = int(spectrum['id'].split('=')[-1])\n",
         "            if scanNumber == scan:\n",
-        "                # This finds the cooresponding values in the .mzml file to create our MS2\n",
+        "                # This finds the corresponding values in the .mzml file to create our MS2\n",
         "                spectrum_id = spectrum['id']\n",
         "                mz = spectrum['m/z array']\n",
         "                intensity = spectrum['intensity array']\n",

--- a/Notebooks_Peptide-ID-and-Quant-of-MS-Data/Lesson_5.ipynb
+++ b/Notebooks_Peptide-ID-and-Quant-of-MS-Data/Lesson_5.ipynb
@@ -811,7 +811,7 @@
         "    for spectrum in spectra:\n",
         "        scanNumber = int(spectrum['id'].split('=')[-1])\n",
         "        if scanNumber == our_scan:\n",
-        "            # This finds the cooresponding values in the .mzml file\n",
+        "            # This finds the corresponding values in the .mzml file\n",
         "            experimental_spectrum_id = scanNumber\n",
         "            experimental_retention_time = spectrum['scanList']['scan'][0]['scan start time']\n",
         "            experimental_precursor_mz = spectrum['precursorList']['precursor'][0]['isolationWindow']['isolation window target m/z']\n",


### PR DESCRIPTION
This PR fixes a few typos in the notebooks that have been added to the repository.

I also came across the following typos in the embedding tutorial notebooks (not yet added to the repository):

[Chapter 1: Simple Embeddings](https://colab.research.google.com/drive/1A2XCfTDEFdP-CSYHB-M0hoZ-66ckmlTy?usp=sharing):

 > pep = peptides.Peptide(seq)             #Load **sequece** as a Peptide object
 
 > In this encoding we create a matrix where one dimension represents the **lenth** of the sequence (e.g. your name), 
 
 [Chapter 2: Complex Embeddings](https://colab.research.google.com/drive/1Ufrbyjao6lhcL-q6lWodxGTGBXqk-C51?usp=sharing):
 
 > a set of **matricies** known as a tensor
 
 > DeepLC uses a convolutional deep learning architecture with four **diferent** paths for a given encoded peptide.
 
 > each Mass Spectrometry output file may have its own **prefered** methods of representing modifications
 
 > Return a 1x6 matrix of the atom **cound** for a given amino acid
 
 [Chapter 3: Learned Embeddings](https://colab.research.google.com/drive/1FIU5AqrMuzV5v-o8cF7AMY5Ccwh4oqaE?usp=sharing):
 
 > Important gains in computer **hardward** and software
 
 > This timeframe **co-incided** with the huge data generation from genomics.
 
[Chapter 4: Benchmarking Embeddings](https://colab.research.google.com/drive/1YHHYom1nYnaAFsR3B8XU8Qs6cZxHSAME?usp=sharing):

 > In this plot, we can see the loss (error) as the model **interative** learns more through each round of training.
 
 > In this plot we can compare each of the different **embeding** absolute error. 
 
 > As with other plots, methods 3, 4, and 5 all appear **noticably** better than methods 1 and 2.